### PR TITLE
Support for 3000mAh Battery+Back Cover Upgrade kit 

### DIFF
--- a/firmware/export/config/ipod6g.h
+++ b/firmware/export/config/ipod6g.h
@@ -145,7 +145,7 @@
 /* 6g has a standard battery of 550mAh, except for the thick 6g (2007 160gb) which has a standard battery of 850mAh */
 #define BATTERY_CAPACITY_DEFAULT 550 /* default battery capacity */
 #define BATTERY_CAPACITY_MIN     300 /* min. capacity selectable */
-#define BATTERY_CAPACITY_MAX     1000 /* max. capacity selectable */
+#define BATTERY_CAPACITY_MAX     3000 /* max. capacity selectable */
 #define BATTERY_CAPACITY_INC      10 /* capacity increment */
 #define BATTERY_TYPES_COUNT        1 /* only one type */
 

--- a/firmware/export/config/ipodvideo.h
+++ b/firmware/export/config/ipodvideo.h
@@ -144,7 +144,7 @@
 #define BATTERY_CAPACITY_DEFAULT_THICK 600 /* default battery capacity for the
                                               60/80GB model */
 #define BATTERY_CAPACITY_MIN      300 /* min. capacity selectable */
-#define BATTERY_CAPACITY_MAX     1400 /* max. capacity selectable */
+#define BATTERY_CAPACITY_MAX     3000 /* max. capacity selectable */
 #define BATTERY_CAPACITY_INC       50 /* capacity increment */
 #define BATTERY_TYPES_COUNT         1 /* only one type */
 


### PR DESCRIPTION
With the Ipod Classic undergoing a revival, one of the most popular mods after the ssd/flash storage mod is to upgrade from the tiny capacity batteries to 3000mAh battery packs with a slightly thicker cover.

I have linked 2 urls for reference

https://www.amazon.com/gp/offer-listing/B01GPL73SO

http://www.ebay.com/itm/3000mA-Battery-Back-Cover-Upgrade-kits-replacement-for-iPod-Classic-160GB-thin-/301982817879?roken=cUgayN&soutkn=ZPnsyn
